### PR TITLE
feat(git-gabber): parse branch, file and line

### DIFF
--- a/git-gabber/url.swift
+++ b/git-gabber/url.swift
@@ -3,22 +3,32 @@ import Foundation
 
 struct GitURL: ExpressibleByArgument {
     let url: String
+    let isSSH: Bool
     let domain: String
     let username: String
     let repository: String
     var fullPath: String
+    let line: UInt?
+
+    var branch: String?
+    var commit: String?
+    var filePath: String?
 
     init?(argument url: String) {
         self.url = url
+
         if url.hasPrefix("git@") {
+            isSSH = true
             let parts = url.split(separator: "@")[1].split(separator: ":")
             domain = String(parts[0])
             fullPath = String(parts[1])
+            line = nil
         } else {
-            let parsed = URLComponents(string: url)!
+            isSSH = false
+            guard let parsed = URLComponents(string: url) else { return nil }
             domain = parsed.host ?? ""
-            fullPath = parsed.path
-            fullPath = fullPath.replacing(/^\/*/, with: "")
+            fullPath = parsed.path.replacing(/^\/*/, with: "")
+            line = Self.parseLineNumber(from: parsed)
         }
 
         fullPath = fullPath.replacing(/\.git$/, with: "")
@@ -27,9 +37,46 @@ struct GitURL: ExpressibleByArgument {
             let parts = fullPath.split(separator: "/")
             username = String(parts[0])
             repository = String(parts[1])
+            if parts.count > 2 {
+                parseAdditionalPathComponents(parts: parts.dropFirst(2))
+            }
         } else {
             username = ""
             repository = fullPath
         }
+    }
+
+    static private func parseLineNumber(from parsed: URLComponents) -> UInt? {
+        guard let fragment = parsed.fragment else { return nil }
+        if fragment.starts(with: "L") {
+            let idx = fragment.index(after: fragment.startIndex)
+            return UInt(fragment[idx...])
+        }
+        return nil
+    }
+
+    private mutating func parseAdditionalPathComponents(parts: ArraySlice<Substring>) {
+        guard let first = parts.first else { return }
+        let rest = parts.dropFirst()
+
+        switch first {
+        case "blob", "tree":
+            guard let branch = rest.first else { break }
+            self.branch = String(branch)
+            if rest.count > 1 {
+                filePath = rest.dropFirst().joined(separator: "/")
+            }
+
+        case "commit":
+            guard let commit = rest.first else { break }
+            self.commit = String(commit)
+
+        default:
+            break
+        }
+    }
+
+    var cloneURL: String {
+        if isSSH { url } else { "https://\(domain)/\(username)/\(repository).git" }
     }
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the `git-gabber` project, particularly focusing on improving the handling of Git URLs and the cloning process. The most significant changes include adding support for branches and commits, enhancing the editor command functionality, and updating the `GitURL` structure to parse additional path components.

Enhancements to Git URL handling and cloning:

* [`git-gabber/gabber.swift`](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bL49-R75): Modified the `cmd` function to use `url.cloneURL` instead of `url.url` when cloning repositories. Added support for checking out a specific branch or commit after cloning.
* [`git-gabber/url.swift`](diffhunk://#diff-3687b291b1c0c608719521df350005d2ce32ce07bb53a0aa17b39b18f02680f0R6-R31): Updated the `GitURL` structure to include properties for `branch`, `commit`, `filePath`, and `line`. Added methods to parse these components from the URL. [[1]](diffhunk://#diff-3687b291b1c0c608719521df350005d2ce32ce07bb53a0aa17b39b18f02680f0R6-R31) [[2]](diffhunk://#diff-3687b291b1c0c608719521df350005d2ce32ce07bb53a0aa17b39b18f02680f0R40-R81)

Enhancements to editor command functionality:

* [`git-gabber/gabber.swift`](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bR91-R103): Introduced the `editorCmd` function to construct the editor command, including navigation to a specific file and line if provided. Updated the tmux command to use this new editor command.