### PR TITLE
ci: parallelize and run on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: package.json
-      - name: Setup tools
+      - name: Setup build tools
         run: |
           brew install just
           sudo xcode-select --switch /Applications/Xcode_16.2.app
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: package.json
-      - name: Install tools
+      - name: Setup build tools
         run: |
           brew install just
           sudo xcode-select --switch /Applications/Xcode_16.2.app
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: package.json
-      - name: Install just
+      - name: Setup build tools
         run: |
           brew install just
           brew install --cask firefox@esr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       GABBER_CI: "true"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup tools
+      - name: Setup build tools
         run: |
           brew install just
           sudo xcode-select --switch /Applications/Xcode_16.2.app

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,33 +1,76 @@
 on:
   pull_request: {}
+  push:
+    branches:
+      - main
 
 jobs:
-  ci:
+  build:
     runs-on: macos-latest
+    env:
+      GABBER_CI: "true"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup tools
+        run: |
+          brew install just
+          sudo xcode-select --switch /Applications/Xcode_16.2.app
+      - name: Build apps
+        run: just build Release
+
+  format:
+    runs-on: macos-latest
+    env:
+      GABBER_CI: "true"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: package.json
-          cache: npm
-          cache-dependency-path: package-lock.json
+      - name: Setup tools
+        run: |
+          brew install just
+          sudo xcode-select --switch /Applications/Xcode_16.2.app
+      - name: Setup npm dependencies
+        run: |
+          npm ci
+      - name: Check formatting
+        run: just check-format
+
+  lint:
+    runs-on: macos-latest
+    env:
+      GABBER_CI: "true"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: package.json
       - name: Install tools
         run: |
           brew install just
-          brew install --cask firefox@esr
           sudo xcode-select --switch /Applications/Xcode_16.2.app
-      - name: Build apps
+      - name: Setup npm dependencies
         run: |
-          just build Release
-      - name: Check formatting
-        if: ${{ !cancelled() }}
-        run: |
-          just check-format
+          npm ci
       - name: Check linting
-        if: ${{ !cancelled() }}
+        run: just check-lint
+
+  test:
+    runs-on: macos-latest
+    env:
+      GABBER_CI: "true"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version-file: package.json
+      - name: Install just
         run: |
-          just check-lint
-      - name: Test
-        if: ${{ !cancelled() }}
+          brew install just
+          brew install --cask firefox@esr
+      - name: Setup npm dependencies
         run: |
-          just test-extension
+          npm ci
+      - name: Test extension
+        run: just test-extension

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ xcodescheme := 'gabber'
 xcderived := join('DerivedData', 'gabber')
 xcarchive := join(out, 'Gabber.xcarchive')
 
-CI := env('CI', 'false')
+CI := env('GABBER_CI', 'false')
 swiftlint_reporter := if CI == 'true' { 'github-actions-logging' } else { 'emoji' }
 codesigning := if CI == 'true' { 'NO' } else { 'YES' }
 
@@ -26,9 +26,6 @@ _xcode config = 'Release' *args:
 
 _deps-xcode: (_xcode 'Debug' '-resolvePackageDependencies')
 
-_deps-npm:
-    npm install
-
 # Check formatting and linting
 check: check-format check-lint
 
@@ -43,7 +40,7 @@ check-lint-xcode: _deps-xcode
         gabber git-gabber
 
 # Check linting for browser extension
-check-lint-npm: _deps-npm
+check-lint-npm:
     npm run lint
 
 # Check formatting
@@ -54,7 +51,7 @@ check-format-swift:
     swift format lint --recursive gabber git-gabber
 
 # Check formatting for other files
-check-format-other: _deps-npm
+check-format-other:
     npx prettier --check .
 
 # Run tests for extension


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD pipeline configuration and the `justfile`. The changes aim to enhance the build, format, lint, and test processes.

CI/CD Pipeline Enhancements:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR3-R76): Added new jobs for build, format, lint, and test processes, and configured them to run on `macos-latest`. The `push` event is now triggered for the `main` branch. Environment variables and setup steps for tools and dependencies were also added.

Updates to `justfile`:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L11-R11): Changed the environment variable from `CI` to `GABBER_CI` and updated the logic for `swiftlint_reporter` and `codesigning`.
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L29-L31): Removed the `_deps-npm` dependency from `check-lint-npm` and `check-format-other` targets. [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L29-L31) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L46-R43) [[3]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L57-R54)