### PR TITLE
feat(cli): vscode support

### DIFF
--- a/git-gabber/errors.swift
+++ b/git-gabber/errors.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum GabberError: LocalizedError {
-    case noTmux
+    case programsNotFound([String])
     case cmdRun(Error)
     case cmd(String, Int32)
     case tmp(Error)
@@ -9,8 +9,12 @@ enum GabberError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .noTmux:
-            return "tmux not installed"
+        case .programsNotFound(let programs):
+            if programs.count == 1 {
+                return "program '\(programs[0])' not found"
+            } else {
+                return "programs '\(programs.joined(separator: "', '"))' not found"
+            }
         case .cmdRun(let err):
             return "failed to execute command: \(err.localizedDescription)"
         case .cmd(let out, let code):

--- a/git-gabber/utils.swift
+++ b/git-gabber/utils.swift
@@ -30,7 +30,7 @@ class TemporaryDirectory {
 }
 
 @discardableResult
-func cmd(_ cmd: String, _ args: [String]) throws -> String {
+func cmd(_ cmd: String, _ args: [String]) throws(GabberError) -> String {
     let task = Process()
     let pipe = Pipe()
 
@@ -57,6 +57,6 @@ func cmd(_ cmd: String, _ args: [String]) throws -> String {
 }
 
 @discardableResult
-func shell(_ command: String) throws -> String {
+func shell(_ command: String) throws(GabberError) -> String {
     try cmd("/bin/sh", ["-c", command])
 }


### PR DESCRIPTION
This pull request includes significant changes to the `git-gabber` project, mainly focusing on error handling improvements, refactoring, and enhancing the program's flexibility when dealing with editors and required programs.

### Error Handling Improvements:
* [`git-gabber/errors.swift`](diffhunk://#diff-94c04f6c3240f9d15e6b8952fd5f09672cce957ad5e4fb522dec5d503f6795c9L4-R17): Introduced a new error case `programsNotFound([String])` to handle scenarios where required programs are not found, replacing the old `noTmux` case. The error description now dynamically lists the missing programs.

### Refactoring and Enhancements:
* [`git-gabber/gabber.swift`](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bL4-R4): Refactored the `Gabber` struct to remove the hardcoded `brewenv` and `git` path options, replacing them with more flexible handling of the editor variable and sourcing the shell environment. Introduced new methods `resolveEditor()`, `findPrograms(_:)`, `clone(with:into:)`, `editorCmd(for:withPath:_:)`, and `spawn(tmux:cmd:in:)` to modularize and simplify the code. [[1]](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bL4-R4) [[2]](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bL17-R106) [[3]](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bR120-R155) [[4]](diffhunk://#diff-11b3ba22dd9f0449dfd4a4515db4ac631edf2ec0ea958267434e10662eee170bL91-L103)

### Utility Function Updates:
* [`git-gabber/utils.swift`](diffhunk://#diff-634b533967bbf5ab5cbf7588543bc9505325864b1060d5de2f9acb23d931a508L33-R33): Updated the `cmd` and `shell` functions to throw `GabberError` for better error handling consistency across the codebase. [[1]](diffhunk://#diff-634b533967bbf5ab5cbf7588543bc9505325864b1060d5de2f9acb23d931a508L33-R33) [[2]](diffhunk://#diff-634b533967bbf5ab5cbf7588543bc9505325864b1060d5de2f9acb23d931a508L60-R60)