### PR TITLE
chore(dependabot): group eslint updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      eslint:
+        patterns:
+          - "@eslint*"
+          - "eslint*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yaml` file to introduce dependency grouping for `eslint` packages. 

Dependency management changes:

* Added a new `groups` section under `updates:` to group `eslint` dependencies based on patterns matching `@eslint*` and `eslint*`.